### PR TITLE
fix Makefile

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -44,7 +44,7 @@ $(HEX): $(ASM)
 
 # Disassemble
 dis: $(HEX)
-	$(DASM) -p p$(AS_DEVICE) $(HEX)
+	$(DASM) -p $(AS_DEVICE) $(HEX)
 
 # List supported device types
 list-devices:


### PR DESCRIPTION
It's just a fix in the Makefile, removing a `p` where it was not needed.
I'm aware it's not a big deal as it is for disassembling, but we never know !  